### PR TITLE
refactor: remove message content constraint from assistant transcript…

### DIFF
--- a/lib/clarice_cochran/notification_hook_command_builder.rb
+++ b/lib/clarice_cochran/notification_hook_command_builder.rb
@@ -14,12 +14,12 @@ module ClariceCochran
 
     private
 
-    def latest_transcript_with_message
-      transcript_file_parser.latest_assistant_transcript_with_message
+    def latest_transcript
+      transcript_file_parser.latest_assistant_transcript
     end
 
     def latest_message_content_text
-      transcript = latest_transcript_with_message
+      transcript = latest_transcript
       transcript.message_contents.last.message
     end
   end

--- a/lib/clarice_cochran/stop_hook_command_builder.rb
+++ b/lib/clarice_cochran/stop_hook_command_builder.rb
@@ -14,12 +14,12 @@ module ClariceCochran
 
     private
 
-    def latest_transcript_with_message
-      transcript_file_parser.latest_assistant_transcript_with_message
+    def latest_transcript
+      transcript_file_parser.latest_assistant_transcript
     end
 
     def latest_message_content_text
-      transcript = latest_transcript_with_message
+      transcript = latest_transcript
       transcript.message_contents.last.message
     end
   end

--- a/lib/clarice_cochran/transcript_file_parser.rb
+++ b/lib/clarice_cochran/transcript_file_parser.rb
@@ -18,14 +18,14 @@ module ClariceCochran
       @objects ||= lines.map { |l| TranscriptParser.new(JSON.parse(l)) }
     end
 
-    def assistant_transcripts_with_messages
+    def assistant_transcripts
       parse.filter do |transcript|
-        transcript.type_assistant? && transcript.message_contents.any?
+        transcript.type_assistant?
       end
     end
 
-    def latest_assistant_transcript_with_message
-      assistant_transcripts_with_messages.max_by(&:timestamp)
+    def latest_assistant_transcript
+      assistant_transcripts.max_by(&:timestamp)
     end
   end
 end


### PR DESCRIPTION
Renamed methods to reflect broader scope:
- `assistant_transcripts_with_messages` → `assistant_transcripts`
- `latest_assistant_transcript_with_message` → `latest_assistant_transcript`

Removed the `message_contents.any?` constraint, allowing these methods
to return all assistant transcripts regardless of whether they contain
message content.