### PR TITLE
feat: support plan field in tool_use message content

### DIFF
--- a/lib/clarice_cochran/transcript_message_content_parser.rb
+++ b/lib/clarice_cochran/transcript_message_content_parser.rb
@@ -41,7 +41,7 @@ module ClariceCochran
     # @todo
     def message
       if type_tool_use?
-        input["description"] || ""
+        input["description"] || input["plan"] || ""
       elsif type_thinking?
         thinking
       elsif type_tool_result?


### PR DESCRIPTION
Add fallback to input["plan"] when input["description"] is not available
in tool_use type messages. This enables displaying plan content when
Claude Code reports plans in plan mode notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>