### PR TITLE
chore: remove unnecessary notification_type from osascript notifications

### DIFF
--- a/lib/clarice_cochran/stop_hook_command_builder.rb
+++ b/lib/clarice_cochran/stop_hook_command_builder.rb
@@ -9,7 +9,7 @@ module ClariceCochran
     end
 
     def to_osascript
-      "osascript -e 'display notification \"#{latest_message_content_text}\" with title \"#{hook_event_name} - Claude Code\" subtitle \"#{notification_type}\" sound name \"Tink\"'"
+      "osascript -e 'display notification \"#{latest_message_content_text}\" with title \"#{hook_event_name} - Claude Code\" sound name \"Tink\"'"
     end
 
     private

--- a/lib/clarice_cochran/user_prompt_submit_hook_command_builder.rb
+++ b/lib/clarice_cochran/user_prompt_submit_hook_command_builder.rb
@@ -9,7 +9,7 @@ module ClariceCochran
     end
 
     def to_osascript
-      "osascript -e 'display notification \"#{prompt}\" with title \"#{hook_event_name} - Claude Code\" subtitle \"#{notification_type}\" sound name \"Tink\"'"
+      "osascript -e 'display notification \"#{prompt}\" with title \"#{hook_event_name} - Claude Code\" sound name \"Tink\"'"
     end
   end
 end


### PR DESCRIPTION
stop_hook と user_prompt_submit_hook において、subtitle パラメータとして
使用していた notification_type を削除。これらのフックでは subtitle は
不要なため、シンプルな通知表示に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)