### PR TITLE
feat: add permission_prompt? and idle_prompt? methods to Notification…

### DIFF
--- a/lib/clarice_cochran/notification_hook_command_builder.rb
+++ b/lib/clarice_cochran/notification_hook_command_builder.rb
@@ -8,6 +8,14 @@ module ClariceCochran
       @data = data
     end
 
+    def permission_prompt?
+      notification_type == "permission_prompt"
+    end
+
+    def idle_prompt?
+      notification_type == "idle_prompt"
+    end
+
     def to_osascript
       "osascript -e 'display notification \"#{latest_message_content_text}\" with title \"#{hook_event_name} - Claude Code\" subtitle \"#{notification_type}\" sound name \"Tink\"'"
     end

--- a/spec/notification_hook_command_builder_spec.rb
+++ b/spec/notification_hook_command_builder_spec.rb
@@ -16,4 +16,44 @@ RSpec.describe ClariceCochran::NotificationHookCommandBuilder do
       expect(builder.message).to eq("")
     end
   end
+
+  describe "#permission_prompt?" do
+    it "returns true when notification_type is permission_prompt" do
+      data = JSON.parse('{ "notification_type": "permission_prompt" }')
+      builder = ClariceCochran::NotificationHookCommandBuilder.new(data)
+      expect(builder.permission_prompt?).to be true
+    end
+
+    it "returns false when notification_type is idle_prompt" do
+      data = JSON.parse('{ "notification_type": "idle_prompt" }')
+      builder = ClariceCochran::NotificationHookCommandBuilder.new(data)
+      expect(builder.permission_prompt?).to be false
+    end
+
+    it "returns false when notification_type is not present" do
+      data = JSON.parse("{}")
+      builder = ClariceCochran::NotificationHookCommandBuilder.new(data)
+      expect(builder.permission_prompt?).to be false
+    end
+  end
+
+  describe "#idle_prompt?" do
+    it "returns true when notification_type is idle_prompt" do
+      data = JSON.parse('{ "notification_type": "idle_prompt" }')
+      builder = ClariceCochran::NotificationHookCommandBuilder.new(data)
+      expect(builder.idle_prompt?).to be true
+    end
+
+    it "returns false when notification_type is permission_prompt" do
+      data = JSON.parse('{ "notification_type": "permission_prompt" }')
+      builder = ClariceCochran::NotificationHookCommandBuilder.new(data)
+      expect(builder.idle_prompt?).to be false
+    end
+
+    it "returns false when notification_type is not present" do
+      data = JSON.parse("{}")
+      builder = ClariceCochran::NotificationHookCommandBuilder.new(data)
+      expect(builder.idle_prompt?).to be false
+    end
+  end
 end


### PR DESCRIPTION
…HookCommandBuilder

notification_typeがpermission_promptかidle_promptかを判断するメソッドを追加しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)