### PR TITLE
chore: remove hardcoded "Claude Code" suffix from notification title

### DIFF
--- a/lib/clarice_cochran/notification_hook_command_builder.rb
+++ b/lib/clarice_cochran/notification_hook_command_builder.rb
@@ -17,7 +17,7 @@ module ClariceCochran
     end
 
     def to_osascript
-      "osascript -e 'display notification \"#{latest_message_content_text}\" with title \"#{message} - Claude Code\" subtitle \"#{notification_type}\" sound name \"Tink\"'"
+      "osascript -e 'display notification \"#{latest_message_content_text}\" with title \"#{message}\" subtitle \"#{notification_type}\" sound name \"Tink\"'"
     end
 
     private


### PR DESCRIPTION
通知タイトルからハードコーディングされていた " - Claude Code" サフィックスを削除し、 messageの内容のみを表示するようにシンプル化しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)