### PR TITLE
chore: remove subtitle parameter from notification

### DIFF
--- a/lib/clarice_cochran/notification_hook_command_builder.rb
+++ b/lib/clarice_cochran/notification_hook_command_builder.rb
@@ -17,7 +17,7 @@ module ClariceCochran
     end
 
     def to_osascript
-      "osascript -e 'display notification \"#{latest_message_content_text}\" with title \"#{message}\" subtitle \"#{notification_type}\" sound name \"Tink\"'"
+      "osascript -e 'display notification \"#{latest_message_content_text}\" with title \"#{message}\" sound name \"Tink\"'"
     end
 
     private


### PR DESCRIPTION
osascriptの通知からsubtitleパラメータを削除し、
通知表示をよりシンプルにしました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)