### PR TITLE
fix: add shell-safe message escaping for hook commands

### DIFF
--- a/lib/clarice_cochran/notification_hook_command_builder.rb
+++ b/lib/clarice_cochran/notification_hook_command_builder.rb
@@ -28,7 +28,7 @@ module ClariceCochran
 
     def latest_message_content_text
       transcript = latest_transcript
-      transcript.message_contents.last.message
+      transcript.message_contents.last.shell_safe_message
     end
   end
 end

--- a/lib/clarice_cochran/stop_hook_command_builder.rb
+++ b/lib/clarice_cochran/stop_hook_command_builder.rb
@@ -20,7 +20,7 @@ module ClariceCochran
 
     def latest_message_content_text
       transcript = latest_transcript
-      transcript.message_contents.last.message
+      transcript.message_contents.last.shell_safe_message
     end
   end
 end

--- a/lib/clarice_cochran/transcript_message_content_parser.rb
+++ b/lib/clarice_cochran/transcript_message_content_parser.rb
@@ -36,5 +36,9 @@ module ClariceCochran
         text
       end
     end
+
+    def shell_safe_message
+      message.gsub("\"", "\\\"")
+    end
   end
 end


### PR DESCRIPTION
Add shell_safe_message method to escape double quotes in message content, and update hook command builders to use it for safer shell execution